### PR TITLE
Added 'x' button to locations in the compare locations tab

### DIFF
--- a/cyan_angular/src/app/location-compare/location-compare.component.html
+++ b/cyan_angular/src/app/location-compare/location-compare.component.html
@@ -47,6 +47,7 @@
           </div>
         </div>
       </div>
+      <button style="float:right;" mat-button (click)="removeLocation(location);">x</button>
     </li>
   </ul>
   <div class="compare-btn-div">

--- a/cyan_angular/src/app/location-compare/location-compare.component.ts
+++ b/cyan_angular/src/app/location-compare/location-compare.component.ts
@@ -31,7 +31,11 @@ export class LocationCompareComponent implements OnInit {
   }
 
   removeLocation(loc: Location): void {
-    this.locationService.deleteCompareLocation(loc);
+    // Removes location from selected locations array:
+    let locIndex = this.selected_locations.map((item) => { return item.id; }).indexOf(loc.id);
+    if (locIndex > -1) {
+      this.selected_locations.splice(locIndex, 1);
+    }
   }
 
   hasLocations(): boolean {


### PR DESCRIPTION
**Expected Behavior:**
- Clicking 'x' button for a location in the compare locations list should remove it from the list and update the compare tab's badge counter.

**TODOs:**
- Styling improvements for 'x' button.