### PR TITLE
fix for only first line in location-compare bloom chart being straight

### DIFF
--- a/cyan_angular/src/app/location-compare-details/location-compare-details.component.ts
+++ b/cyan_angular/src/app/location-compare-details/location-compare-details.component.ts
@@ -74,7 +74,6 @@ export class LocationCompareDetailsComponent implements OnInit {
       pointBorderColor: '#00FFFF',
       pointHoverBackgroundColor: '#00FFFF',
       pointHoverBorderColor: 'rgba(0,255,255,0.8)',
-      lineTension: 0
     }
   ];
   public chartLegend: boolean = true;
@@ -182,7 +181,8 @@ export class LocationCompareDetailsComponent implements OnInit {
       // Adds time series line to chart:
       this.chartData.push({
         data: timeSeriesData,
-        label: l.name
+        label: l.name,
+        lineTension: 0
       });
 
       this.dataDownloaded = true;


### PR DESCRIPTION
location-compare plots had the first set of data with a straight line, but the remaining plots were the default curvy lines. this should be resolved now.