### PR TITLE
Updated the create/remove mark flow

### DIFF
--- a/cyan_angular/src/app/coordinates/coordinates.component.ts
+++ b/cyan_angular/src/app/coordinates/coordinates.component.ts
@@ -95,28 +95,7 @@ export class CoordinatesComponent implements OnInit {
 		location = this.locationService.createLocation(name, latLon.lat, latLon.lng, cellCon, maxCellCon, cellChange, dataDate, source);
 
 		map.setView(latLon, 12);
-		let m = marker(this.mapService.getLatLng(location), {
-			icon: icon({
-				iconSize: [30, 36],
-				iconAnchor: [13, 41],
-				iconUrl: this.getMarker(location.cellConcentration, location.marked),
-				shadowUrl: 'leaflet/marker-shadow.png'
-			}),
-			title: location.name,
-			riseOnHover: true,
-			zIndexOffset: 10000
-		});
-		let self = this;
-		m.on('click', function(e) {
-			let p = self.mapService.createPopup(self.locationService.getLocationByID(location.id));
-			let o = {
-				keepInView: true
-			};
-			map.setView(m.getLatLng(), 12);
-			m.bindPopup(p, o).openPopup();
-			m.unbindPopup();
-		});
-		this.mapService.addMarker(location.id, m);
+		let m = this.mapService.addMarker(location);
 		m.fireEvent('click');
 
 		return location;

--- a/cyan_angular/src/app/location-compare-details/location-compare-details.component.ts
+++ b/cyan_angular/src/app/location-compare-details/location-compare-details.component.ts
@@ -152,15 +152,7 @@ export class LocationCompareDetailsComponent implements OnInit {
   downloadTimeSeries(l: Location) {
     let coord = this.locationService.convertToDegrees(l);
     let username = this.user.getUserName();
-    this.downloader.getAjaxData(
-      l.id,
-      username,
-      l.name,
-      l.marked,
-      coord.latitude,
-      coord.longitude,
-      false
-    );
+    this.downloader.getAjaxData(username, l);
 
     this.tsSub = this.downloader.getTimeSeries().subscribe((rawData: RawData[]) => {
       let data = rawData[l.id].requestData;

--- a/cyan_angular/src/app/location-details/location-details.component.ts
+++ b/cyan_angular/src/app/location-details/location-details.component.ts
@@ -385,17 +385,8 @@ export class LocationDetailsComponent implements OnInit {
   }
 
   downloadTimeSeries() {
-    let coord = this.locationService.convertToDegrees(this.current_location);
     let username = this.user.getUserName();
-    this.downloader.getAjaxData(
-      this.current_location.id,
-      username,
-      this.current_location.name,
-      this.current_location.marked,
-      coord.latitude,
-      coord.longitude,
-      false
-    );
+    this.downloader.getAjaxData(username, this.current_location);
     this.chartData = [];
     let self = this;
     this.tsSub = this.downloader.getTimeSeries().subscribe((rawData: RawData[]) => {

--- a/cyan_angular/src/app/map-popup/map-popup.component.ts
+++ b/cyan_angular/src/app/map-popup/map-popup.component.ts
@@ -6,8 +6,6 @@ import { Router } from '@angular/router';
 import { Location } from '../models/location';
 import { LocationService } from '../services/location.service';
 import { MapService } from '../services/map.service';
-
-import { DownloaderService } from '../services/downloader.service';
 import { UserService } from '../services/user.service';
 
 @Component({
@@ -25,7 +23,6 @@ export class MapPopupComponent implements OnInit {
   constructor(
     private locationService: LocationService,
     private mapService: MapService,
-    private downloaderService: DownloaderService,
     private user: UserService,
     private datePipe: DatePipe,
     private router: Router
@@ -41,7 +38,7 @@ export class MapPopupComponent implements OnInit {
       setTimeout(function() {
         self.getLocation();
         self.marked = self.location.marked ? 'Mark' : 'Unmark';
-        self.locationService.downloadLocation(self.location, true);
+        self.locationService.downloadLocation(self.location);
       }, 300);
     }
   }
@@ -61,9 +58,13 @@ export class MapPopupComponent implements OnInit {
     }
     self.locationSubscription = self.locationService.getLocationData().subscribe({
       next(locations) {
-        self.locationData = locations.filter(l => {
-          return l.id == self.location.id;
-        })[0];
+        if (!self.location) {
+          self.locationData = null;
+        } else {
+          self.locationData = locations.filter(l => {
+            return l.id == self.location.id;
+          })[0];
+        }
         if (self.locationData == null) {
           setTimeout(function() {
             self.getLocation();
@@ -77,6 +78,7 @@ export class MapPopupComponent implements OnInit {
           }
           else {
             self.location = self.locationData;
+            self.mapService.updateMarker(self.location);
           }
         }
       },
@@ -172,10 +174,7 @@ export class MapPopupComponent implements OnInit {
   }
 
   deleteLocation(ln: Location): void {
-    let self = this;
     this.mapService.deleteMarker(ln);
-    setTimeout(function() {
-      self.locationService.deleteLocation(ln);
-    }, 1000);
+    this.locationService.deleteLocation(ln);
   }
 }

--- a/cyan_angular/src/app/marker-map/marker-map.component.ts
+++ b/cyan_angular/src/app/marker-map/marker-map.component.ts
@@ -21,7 +21,6 @@ export class MarkerMapComponent implements OnInit {
   lat_0: number = 33.927945;
   lng_0: number = -83.346554;
 
-  locations: Location[];
   marker_layers: LayerGroup;
 
   esriImagery = tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
@@ -74,15 +73,12 @@ export class MarkerMapComponent implements OnInit {
   }
 
   getLocations(): void {
-    this.locationService.getLocations(this.mapService.getSource()).subscribe(location => (this.locations = location));
+    this.locationService.getLocations(this.mapService.getSource()).subscribe();
   }
 
   onMapReady(map: Map) {
     // Initialize Map
     this.mapService.setMap(map);
-
-    // Add markers from list of user locations
-    this.addMarkers(map);
   }
 
   addMarkerOnClick(e: any): void {
@@ -99,62 +95,8 @@ export class MarkerMapComponent implements OnInit {
 
     let location = this.locationService.createLocation(name, lat, lng, cellCon, maxCellCon, cellChange, dataDate, source);
     map.setView(e.latlng, 12);
-    let m = marker(this.mapService.getLatLng(location), {
-      icon: icon({
-        iconSize: [30, 36],
-        iconAnchor: [13, 41],
-        iconUrl: this.getMarker(location.cellConcentration, location.marked),
-        shadowUrl: 'leaflet/marker-shadow.png'
-      }),
-      title: location.name,
-      riseOnHover: true,
-      zIndexOffset: 10000
-    });
-    let self = this;
-    m.on('click', function(e) {
-      let p = self.mapService.createPopup(self.locationService.getLocationByID(location.id));
-      let o = {
-        keepInView: true
-      };
-      map.setView(m.getLatLng(), 12);
-      m.bindPopup(p, o).openPopup();
-      m.unbindPopup();
-    });
-    this.mapService.addMarker(location.id, m);
+    let m = this.mapService.addMarker(location);
     m.fireEvent('click');
-  }
-
-  addMarkers(map: Map): void {
-    this.locations.forEach(location => {
-      let self = this;
-      if (!self.mapService.hasMarker(location.id)) {
-        let m = marker(this.mapService.getLatLng(location), {
-          icon: icon({
-            iconSize: [30, 36],
-            iconAnchor: [13, 41],
-            iconUrl: this.getMarker(location.cellConcentration, location.marked),
-            shadowUrl: 'leaflet/marker-shadow.png'
-          }),
-          title: location.name,
-          riseOnHover: true,
-          zIndexOffset: 10000
-        });
-        m.on('click', function(e) {
-          let p = self.mapService.createPopup(self.locationService.getLocationByID(location.id));
-          let o = {
-            keepInView: true
-          };
-          map.setView(m.getLatLng(), 12);
-          m.bindPopup(p, o).openPopup();
-          m.unbindPopup();
-        });
-        this.mapService.addMarker(location.id, m);
-      }
-    });
-    let self = this;
-    setTimeout(function() {
-      self.addMarkers(map);
-    }, 100);
   }
 
   getMarker(n: number, c: boolean): string {

--- a/cyan_angular/src/app/models/location.ts
+++ b/cyan_angular/src/app/models/location.ts
@@ -1,6 +1,8 @@
 export class Location {
   id: number;
   name: string;
+  latitude: number;
+  longitude: number;
   latitude_deg: number;
   latitude_min: number;
   latitude_sec: number;

--- a/cyan_angular/src/app/test-data/test-locations.ts
+++ b/cyan_angular/src/app/test-data/test-locations.ts
@@ -4,6 +4,8 @@ export const LOCATIONS: Location[] = [
   {
     id: 100001,
     name: 'Sand Creek Park',
+    latitude: 34.03472222,
+    longitude: -83.38138889,
     latitude_deg: 34,
     latitude_min: 2,
     latitude_sec: 5,
@@ -26,6 +28,8 @@ export const LOCATIONS: Location[] = [
   {
     id: 100002,
     name: 'Lake Okeechobee',
+    latitude: 27.03222222,
+    longitude: -80.77722222,
     latitude_deg: 27,
     latitude_min: 1,
     latitude_sec: 56,
@@ -48,6 +52,8 @@ export const LOCATIONS: Location[] = [
   {
     id: 100003,
     name: 'Devils Elbow Post Light',
+    latitude: 28.63361111,
+    longitude: -81.62500000,
     latitude_deg: 28,
     latitude_min: 38,
     latitude_sec: 1,
@@ -70,6 +76,8 @@ export const LOCATIONS: Location[] = [
   {
     id: 100004,
     name: 'Chestatee Bay',
+    latitude: 34.27055556,
+    longitude: -83.95583333,
     latitude_deg: 34,
     latitude_min: 16,
     latitude_sec: 14,


### PR DESCRIPTION
This address 2 ticket: cyan-433 and cyan-410
1. Change the flow to create user location immediately when click on map (was to create user location till get location data). Update user location when get location data returns. This was because user may click on `Remove` button before get location data returns, can caused marker/location list mismatch.
2. Also refactored the code to re-use code
3. For the marker hover not updated issue, I didn't figure out how to re-load the leaflit marker image title. So changed to use a tooltip and update the tooltip content when location data comes back.

Another though, we may want to get the location name from client, instead of the metadata returned from API.