### PR TITLE
cyan-377: fix for mark/unmark location toggling

### DIFF
--- a/cyan_angular/src/app/map-popup/map-popup.component.ts
+++ b/cyan_angular/src/app/map-popup/map-popup.component.ts
@@ -131,9 +131,8 @@ export class MapPopupComponent implements OnInit {
   }
 
   toggleMarkedLocation(ln: Location): void {
-    let m = this.marked == 'Mark' ? false : true;
-    this.locationService.setMarked(ln, m);
-
+    let m = ln.marked;
+    this.locationService.setMarked(ln, !m);
     // Change mark button label
     let label = document.getElementById('marked-label');
     label.innerHTML = this.marked;


### PR DESCRIPTION
Location popups should show proper toggling of "Mark" and "Unmark" as well as editing the locations in the local database.