### PR TITLE
adds unique id to location names

### DIFF
--- a/cyan_angular/src/app/services/downloader.service.ts
+++ b/cyan_angular/src/app/services/downloader.service.ts
@@ -326,7 +326,7 @@ export class DownloaderService {
     this.locations.forEach((location) => {
       if (location.name.includes(ln.name)) {
         let idNum = location.name.split(" -- ")[1];
-        matchedLocations.push(Number(idNum));
+        if (idNum != undefined) { matchedLocations.push(Number(idNum)); }
       }
     });
     if (matchedLocations.length == 0) {


### PR DESCRIPTION
Adds unique numerical identifier to location name. Starts at 1 if no other locations exists with the same name, otherwise it uses the existing max ID value + 1.