### PR TITLE
Created feature branch with fix for front end response

### DIFF
--- a/cyan_angular/src/app/account/account.component.ts
+++ b/cyan_angular/src/app/account/account.component.ts
@@ -162,10 +162,17 @@ export class AccountComponent implements OnInit {
       }, 100);
       if (response != null) {
         if (response.hasOwnProperty('status')) {
-          self.registerForm = false;
-          self.username = self.registerUsername;
-          self.password = self.registerPassword;
-          self.loginUser();
+          if(response.status == "failure"){
+            console.log(response.status);
+            setTimeout(function() {
+              self.setRegisterMessage('Email adress already taken.');
+            }, 300);
+          } else {
+              self.registerForm = false;
+              self.username = self.registerUsername;
+              self.password = self.registerPassword;
+              self.loginUser();
+            }
         } else {
           setTimeout(function() {
             self.setRegisterMessage('User name already taken.');

--- a/cyan_angular/src/app/services/user.service.ts
+++ b/cyan_angular/src/app/services/user.service.ts
@@ -72,7 +72,7 @@ export class UserService {
     let self = this;
     this.downloader.registerUser(username, email, password).subscribe(response => {
       if(response.hasOwnProperty("status")){
-        if(response['status'] == "success"){
+        if(response['status'] == "success" || response['status'] == "failure"){
           this.currentAccount.user.username = response['username'];
           this.currentAccount.user.email = response['email'];
           this.currentAccount.locations = [];

--- a/cyan_flask/web_app_api.py
+++ b/cyan_flask/web_app_api.py
@@ -68,6 +68,8 @@ def register_user(post_data):
 		query = 'INSERT INTO User(id, username, email, password, created, last_visit) VALUES (%s, %s, %s, %s, %s, %s)'
 		values = (None, user, email, password_salted, date, date,)
 		register = query_database(query, values)
+		if (register == {"error": "Error accessing database"}):
+			return {"status": "failure", "username": user, "email": email}, 200
 		return {"status": "success", "username": user, "email": email}, 200
 
 def login_user(post_data):


### PR DESCRIPTION
This fix now throws a front end error when a user attempts to register an account with an email that is already in use. If both the email address and username have already been registered, the error that is thrown indicates only that the username is already in use.