### PR TITLE
cyan-460 Clicking a tab from location details throws exception, disabling tabs.

### DIFF
--- a/cyan_angular/src/app/location-compare/location-compare.component.html
+++ b/cyan_angular/src/app/location-compare/location-compare.component.html
@@ -6,7 +6,7 @@
       <div id="select-text" class="no_locations location_count"><span class="no_location_title">Select locations to compare ({{selected_locations.length}} locations)</span></div>
   </div>
   <ul class="location_list">
-    <li *ngFor="let location of selected_locations" class="location_li" (click)="locationSelect($event, location)">
+    <li *ngFor="let location of selected_locations" class="location_li">
       <div class="location_name">{{location.name}}</div>
       <div class="left_block">
         <div class="location_block_1">

--- a/cyan_angular/src/app/location-details/location-details.component.ts
+++ b/cyan_angular/src/app/location-details/location-details.component.ts
@@ -191,6 +191,9 @@ export class LocationDetailsComponent implements OnInit {
     */
     setTimeout(() => {
       let thumbs = this.removeThumbHighlights();
+      if (!thumbs || thumbs.length <= 0) {
+        return;
+      }
       this.toggleImage(thumbs[0], this.locationThumbs[0]);
     }, 1000);
   }
@@ -301,13 +304,16 @@ export class LocationDetailsComponent implements OnInit {
       this.current_location.changeDate = locationDataArray[selectedIndex + 1].imageDate.split(' ')[0];
     }
     this.getArrow(this.current_location);  // updates arrow
-    this.getImageDate();  // updates image date
-    this.getImageName();  // updates image name
     this.current_location.cellConcentration = Math.round(locationData.cellConcentration);
     this.current_location.maxCellConcentration = Math.round(locationData.maxCellConcentration);
     this.current_location.validCellCount = locationData.validCellsCount;
     this.current_location.dataDate = locationData.imageDate.split(' ')[0];
-    this.mapService.setMiniMarker(this.createMarker());  // updates marker on minimap
+
+    if (this.selectedLayer != undefined) {
+      this.getImageDate();  // updates image date
+      this.getImageName();  // updates image name
+      this.mapService.setMiniMarker(this.createMarker());  // updates marker on minimap
+    }
   }
 
   clearLayerImages() {
@@ -445,7 +451,11 @@ export class LocationDetailsComponent implements OnInit {
     this.chartData = [];
     let self = this;
     this.tsSub = this.downloader.getTimeSeries().subscribe((rawData: RawData[]) => {
-      let data = rawData[self.current_location.id].requestData;
+      let rawDataObj = rawData[self.current_location.id];
+      if (rawDataObj == undefined) {
+        return;
+      } 
+      let data = rawDataObj.requestData;
       let timeSeriesData = [];
       data.outputs.map(timestep => {
         // Builds data var like [{x: '', y: ''}, {}...]


### PR DESCRIPTION
Jason found this bug that's recreated as follows: click a location in "My Locations," which opens location details. If a user clicks one of the 4 tabs before image data is retrieved, it throws an error at location details while it's being destroyed. This renders the tabs and viewing of components (other than the map itself) useless for a while or until the page is refreshed.