### PR TITLE
GDIT VMs startup and shutdown script

### DIFF
--- a/config/services/cyano.service
+++ b/config/services/cyano.service
@@ -6,6 +6,7 @@ After=network.target
 Type=idle
 ExecStart=/var/tmp/start-app.sh
 TimeoutStartSec=0
+ExecStop=/var/tmp/stop-app.sh
 
 [Install]
 WantedBy=default.target

--- a/config/services/init-services.sh
+++ b/config/services/init-services.sh
@@ -3,7 +3,7 @@
 systemctl daemon-reload
 
 # Enables services:
-systemctl enable start-app.service
+systemctl enable cyano.service
 
 # Starts services:
-systemctl start start-app.service
+systemctl start cyano.service

--- a/config/services/start-app.sh
+++ b/config/services/start-app.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Script file that is executed by cyano.service.
+# Located at /var/tmp/start-app.sh
+
 # Starts docker-compose stack:
 cd /var/www/qed
 export HOSTNAME=${HOSTNAME}

--- a/config/services/stop-app.sh
+++ b/config/services/stop-app.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd /var/www/qed
+docker-compose down


### PR DESCRIPTION
systemd service to spin up docker stack when the VMs start up in the mornings.

- cyano.service -- defines the service itself and the startup and shutdown commands (`/etc/systemd/system/cyano.service`).
- start-app.sh -- starts up docker-compose stack by running docker-compose up (`/var/tmp/start-app.sh`).
- stop-app.sh -- stops docker-compose stack by running docker-compose down (`/var/tmp/stop-app.sh`).
- init-services.sh -- script file for reloading systemd process, enabling, and starting cyano.service (currently not implemented but created to run if service gets updated or new services are added).

Aside from accessing the CEAM development VM early in the morning and checking that the stack is running (starts up at 6:00 AM, shuts down at 10:00 PM), another way to verify the service is the following:
1. Access CEAM development VM with Cloud9 ([documentation](https://smavcs.atlassian.net/wiki/spaces/CYAN/pages/1108508673/How+to+utilize+Cloud9+in+AWS))
2. Check the service's status: `systemctl status cyano`
3. Verify docker stack is actually running: `docker-compose -f /var/www/qed/docker-compose.yml ps`
4. The docker stack can also be stopped with: `sudo systemctl stop cyano`
5. Check that it's stopped: `docker-compose -f /var/www/qed/docker-compose.yml ps`
6. Start it back up: `sudo systemctl start cyano`
7. Check that it's restarted (may take a few seconds): `docker-compose -f /var/www/qed/docker-compose.yml ps`