### PR TITLE
using node LTS version docker image

### DIFF
--- a/Dockerfile_Webserver
+++ b/Dockerfile_Webserver
@@ -1,4 +1,4 @@
-FROM node:12.19.1-alpine as builder
+FROM node:lts-alpine as builder
 
 # Build-time variables
 ARG env=standalone


### PR DESCRIPTION
Simple update using node LTS Docker image; should build without error.