### PR TITLE
angular static content deploy url added for build:qed

### DIFF
--- a/cyan_angular/package.json
+++ b/cyan_angular/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "build:standalone": "ng build --prod --outputPath=dist",
-    "build:qed": "ng build --prod --baseHref=/cyanweb --outputHashing=none --outputPath=../../static_qed/epa-cyano-web",
+    "build:qed": "ng build --prod --baseHref=/cyanweb --deployUrl=/static_qed/epa-cyano-web --outputHashing=none --outputPath=../../static_qed/epa-cyano-web",
     "build:docker": "ng build --configuration=docker --output-path=dist",
     "build:qed-docker": "ng build --configuration=docker --baseHref=/cyanweb --outputHashing=none --outputPath=../../static_qed/epa-cyano-web",
     "build:cyano": "ng build --prod --baseHref=/cyanweb --deployUrl=/cyanweb/ --outputHashing=none --outputPath=dist",


### PR DESCRIPTION
Angular side of fix for broken links in QED deployment. The other component is in qed_nginx with routes to assets and lefalet.