### PR TITLE
Updating Flask-SQLAlchemy

### DIFF
--- a/cyan_flask/requirements.txt
+++ b/cyan_flask/requirements.txt
@@ -4,7 +4,7 @@ Flask==1.1.2
 Flask-Cors==3.0.10
 Flask-Migrate==2.5.3
 Flask-RESTful==0.3.8
-Flask-SQLAlchemy==2.4.4
+Flask-SQLAlchemy==2.5.0
 mysqlclient==2.0.3
 mysql-connector-python==8.0.22
 PyJWT==2.0.0


### PR DESCRIPTION
Fixes the following dependency error:

cyan-api_1        | Traceback (most recent call last):
cyan-api_1        |   File "/cyan_flask/tests/integration_tests.py", line 358, in test_api_integration
cyan-api_1        |     self._setup_db()
cyan-api_1        |   File "/cyan_flask/tests/integration_tests.py", line 136, in _setup_db
cyan-api_1        |     flask_migrate.upgrade()
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/flask_migrate/__init__.py", line 96, in wrapped
cyan-api_1        |     f(*args, **kwargs)
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/flask_migrate/__init__.py", line 271, in upgrade
cyan-api_1        |     command.upgrade(config, revision, sql=sql, tag=tag)
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/alembic/command.py", line 294, in upgrade
cyan-api_1        |     script.run_env()
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/alembic/script/base.py", line 490, in run_env
cyan-api_1        |     util.load_python_file(self.dir, "env.py")
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/alembic/util/pyfiles.py", line 97, in load_python_file
cyan-api_1        |     module = load_module_py(module_id, path)
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/alembic/util/compat.py", line 182, in load_module_py
cyan-api_1        |     spec.loader.exec_module(module)
cyan-api_1        |   File "<frozen importlib._bootstrap_external>", line 783, in exec_module
cyan-api_1        |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
cyan-api_1        |   File "migrations/env.py", line 28, in <module>
cyan-api_1        |     str(current_app.extensions["migrate"].db.engine.url).replace("%", "%%"),
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/flask_sqlalchemy/__init__.py", line 943, in engine
cyan-api_1        |     return self.get_engine()
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/flask_sqlalchemy/__init__.py", line 962, in get_engine
cyan-api_1        |     return connector.get_engine()
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/flask_sqlalchemy/__init__.py", line 555, in get_engine
cyan-api_1        |     options = self.get_options(sa_url, echo)
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/flask_sqlalchemy/__init__.py", line 570, in get_options
cyan-api_1        |     self._sa.apply_driver_hacks(self._app, sa_url, options)
cyan-api_1        |   File "/usr/local/lib/python3.8/site-packages/flask_sqlalchemy/__init__.py", line 884, in apply_driver_hacks
cyan-api_1        |     sa_url.query.setdefault('charset', 'utf8')
cyan-api_1        | AttributeError: 'sqlalchemy.cimmutabledict.immutabledict' object has no attribute 'setdefault'
cyan-api_1        | 