### PR TITLE
Cyan 587 security fix for datatype sql injection

### DIFF
--- a/cyan_flask/app/endpoints.py
+++ b/cyan_flask/app/endpoints.py
@@ -70,7 +70,7 @@ class Login(Resource):
     parser = parser_base.copy()
     parser.add_argument("user", type=str)
     parser.add_argument("password", type=str)
-    parser.add_argument("dataType", type=int)
+    parser.add_argument("dataType", type=int, choices=(1, 2))
 
     def get(self):
         return {"status": "login endpoint"}


### PR DESCRIPTION
Local OWASP ZAP scan was picking up on a SQL injection risk for "dataType" argument in Login endpoint. This is the fix for it.