### PR TITLE
removes double tooltip

### DIFF
--- a/cyan_angular/src/app/services/map.service.ts
+++ b/cyan_angular/src/app/services/map.service.ts
@@ -80,7 +80,6 @@ export class MapService {
 
     let m = marker(this.getLatLng(location), {
       icon: this.createIcon(markerLocation),
-      title: location.name,
       alt: "Map marker for " + location.name,
       riseOnHover: true,
       zIndexOffset: 10000


### PR DESCRIPTION
Hovering markers doesn't show two tooltips anymore, just the one with location name and date.